### PR TITLE
Add some more indentation rules

### DIFF
--- a/indent/haskell.vim
+++ b/indent/haskell.vim
@@ -59,6 +59,15 @@ function! GetHaskellIndent(lnum)
     if l:line =~# 'module.*(\s*$'
         let l:indent = match(l:line, '\S') + &shiftwidth
 
+    " If finishing up a deriving clause, stop indenting
+    elseif l:line =~# 'deriving.*)$'
+        let l:indent = 0
+
+    " If breaking up a type signature for a top-level binding, indent to
+    " the :: so we can easily line up :: and ->
+    elseif l:line =~# '^\S*\s*::'
+        let l:indent = match(l:line, '::')
+
     " indent to the last open list bracket/open paren/open brace
     elseif l:line =~# '\(\[[^\]]*\|([^)]*\|{[^}]*\)$'
         let l:indent = GetBlockMarker(l:line)


### PR DESCRIPTION
Adds a rule for ending indentation after a finished `deriving` and for indenting to `::` if you're breaking up a top-level type signature (to document the arguments, say).  The first rule avoids the need to outdent manually after finishing a type declaration; the second avoids the need to indent manually to align to `::` when breaking up

```
fooBarThing :: Stuff -> Yay
```

into

```
fooBarThing :: Stuff
            -> Yay
```

(although after `Yay` you'll have to manually outdent back to column zero, so depending on your perspective that might not be a net win).
